### PR TITLE
toLong 구현

### DIFF
--- a/src/main/java/kr/co/study/Bytes.java
+++ b/src/main/java/kr/co/study/Bytes.java
@@ -1,0 +1,26 @@
+package kr.co.study;
+
+public class Bytes {
+    public static void main(String[] args) {
+        byte[] input = new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
+        long result = Bytes.toLong(input);
+        System.out.println(result); // 출력: 256
+    }
+
+    private static long toLong(byte[] bytes) {
+
+        checkArrayLengthIs8(bytes);
+        long result = 0;
+        for (byte b : bytes) {
+            result <<= 8;
+            result |= (b & 0xFF);
+        }
+        return result;
+    }
+
+    private static void checkArrayLengthIs8(byte[] bytes) {
+        if (bytes.length != 8) {
+            throw new IllegalArgumentException("배열의 크기가 8이어야 합니다.");
+        }
+    }
+}


### PR DESCRIPTION
1. long 타입은 64bit이기 때문에 8바이트 크기의 배열이 필요하다.
2. 따라서 checkArrayLengthIs8 메서드를 통해 배열 크기가 8인지 먼저 제약조건을 확인한다.
3. long result = 0 에는
[00000000, 00000000, 00000000, 00000000, 00000000, 00000000, 00000000, 00000000]로 초기화 되어 있기 때문에 input에 담긴 값을 하나씩 왼쪽으로 밀어가며 8바이트를 채우기 위한 첫번째 단계로 비트 시프트를 해준다 (result <== 8) : 8비트이기 때문에 8단위 비트 시프트가 이뤄짐. (Big-endian 방식)

4. byte는 -128 ~ 127의 정수를 가질 수 있는데, 결과값으로는 부호 없는 정수가 필요하기 때문에 "& 0xFF" 비트 연산을 통해 양의 정수로 변환한다.


