### PR TITLE
toShort 구현

### DIFF
--- a/src/main/java/kr/co/study/Bytes.java
+++ b/src/main/java/kr/co/study/Bytes.java
@@ -2,9 +2,15 @@ package kr.co.study;
 
 public class Bytes {
     public static void main(String[] args) {
+        // toLong
         byte[] input = new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
         long result = Bytes.toLong(input);
         System.out.println(result); // 출력: 256
+
+        // toShort
+        byte[] input2 = new byte[] { 0x01, 0x02 };
+        short result2 = Bytes.toShort(input2);
+        System.out.println(result2);
     }
 
     private static long toLong(byte[] bytes) {
@@ -18,9 +24,25 @@ public class Bytes {
         return result;
     }
 
+    private static short toShort(byte[] bytes) {
+        checkArrayLengthIs2(bytes);
+        int result  = 0;
+        for (byte b : bytes) {
+            result <<= 8;
+            result |= (b & 0xFF);
+        }
+        return (short) result;
+    }
+
     private static void checkArrayLengthIs8(byte[] bytes) {
         if (bytes.length != 8) {
             throw new IllegalArgumentException("배열의 크기가 8이어야 합니다.");
+        }
+    }
+
+    private static void checkArrayLengthIs2(byte[] bytes) {
+        if (bytes.length != 2) {
+            throw new IllegalArgumentException("배열의 크기가 2이어야 합니다.");
         }
     }
 }

--- a/src/main/java/kr/co/study/Bytes.java
+++ b/src/main/java/kr/co/study/Bytes.java
@@ -1,0 +1,26 @@
+package kr.co.study;
+
+public class Bytes {
+    public static void main(String[] args) {
+        byte[] input = new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
+        long result = Bytes.toLong(input);
+        System.out.println(result); // 출력: 256
+    }
+
+    private static long toLong(byte[] bytes) {
+
+        checkArrayLengthIs8(bytes);
+        long result = 0;
+        for (byte b : bytes) {
+            result <<= 8;
+            result |= (b & 0xFF);
+        }
+        return result;
+    }
+
+    private static void checkArrayLengthIs8(byte[] bytes) {
+        if (bytes.length != 8) {
+            throw new IllegalArgumentException("배열의 크기가 8이어야 합니다.");
+        }
+    }
+}


### PR DESCRIPTION
1. short는 16비트 자료형이기 때문에 2바이트의 크기의 배열이 있어야한다.
2. 1바이트는 8비트이기 때문에 비트 시프트는 8 비트 단위로 시프트 된다.

이하 코드는 toLong과 동일.